### PR TITLE
特定条件下で HOME 変数が空になる問題を修正

### DIFF
--- a/nira.py
+++ b/nira.py
@@ -38,7 +38,7 @@ except BaseException as err:
 
 
 
-HOME = os.path.dirname(__file__)
+HOME = os.path.dirname(os.path.abspath(__file__))
 SETTING = json.load(open(f'{sys.path[0]}/setting.json', 'r'))
 TOKEN = SETTING["tokens"]["nira_bot"]
 PREFIX = SETTING["prefix"]


### PR DESCRIPTION
一番わかりやすいのは `python3 nira.py` で起動した時
詳細: https://note.nkmk.me/python-script-file-path/

Python 3.9 以降では発生しない

ちなみにこれが原因で別の問題も発覚してしまったがそれはまた今度...

追伸: ファイル末尾には改行を入れた方が良い、一部のエディタは勝手に改行を追加するのでコミットログが汚れる原因になる
https://qiita.com/Aseiide/items/e66be44c4b7972902063