### PR TITLE
自動ロールのスラッシュコマンドを追加

### DIFF
--- a/cogs/autorole.py
+++ b/cogs/autorole.py
@@ -74,7 +74,9 @@ class autorole(commands.Cog):
 
     @commands.command(name="autorole", aliases=("自動ロール", "オートロール"), help="""\
     ユーザーが加入したときに、指定したロールを自動的に付与することが出来ます。
-    書き方: `n!autorole [ロール名/ロールID/ロールへのメンション]`
+    ・使い方
+    設定: `n!autorole on [ロール名/ロールID/ロールへのメンション]`
+    無効化: `n!autorole off`
 
     ・例
     ```

--- a/util/slash_tool.py
+++ b/util/slash_tool.py
@@ -19,21 +19,25 @@ class messages:
     def mreply(message, reply_message, **kwargs):
         if kwargs == {}:
             kwargs["embed"] = None
-            kwargs["ephemeral"] = None
+            kwargs["ephemeral"] = False
         elif "embed" not in kwargs:
             kwargs["embed"] = None
         elif "ephemeral" not in kwargs:
-            kwargs["ephemeral"] = None
+            kwargs["ephemeral"] = False
         if type(message) == nextcord.Message:
             return message.reply(reply_message, embed=kwargs["embed"])
         elif type(message) == nextcord.Interaction:
-            return message.response.send_message(reply_message, embed=kwargs["embed"],  ephemeral=kwargs["ephemeral"])
+            # InteractionResponse.send_message は embed=None すると例外を吐く
+            if kwargs["embed"] is None:
+                return message.response.send_message(reply_message, ephemeral=kwargs["ephemeral"])
+            else:
+                return message.response.send_message(reply_message, embed=kwargs["embed"], ephemeral=kwargs["ephemeral"])
         elif type(message) == nextcord.ext.commands.Context:
             return message.reply(reply_message, embed=kwargs["embed"])
         else:
             raise TypeError
             return
-    
+
     def content_check(message):
         if type(message) == nextcord.Message:
             return message.content


### PR DESCRIPTION
メッセージはオリジナルを尊重してとりあえず似たような書式にした  
でもEmbedだったりそうでなかったりして統一性が無いので気に入ってはいない

Usage:
- `/autorole on [ロール]`
  - ロールはクライアントのオートコンプリート対応、変な値はそもそも送信されない
- `/autorole off`
- `/autorole status`

おまけ
- `@everyone` を弾く
- `n!autorole` でメンションに対応
- `n!autorole` で名前が数字のみのロールに対応
  - 数値の場合はIDとして検索し、無かった場合は名前として再検索する
  - ~~メンションできるんだからIDいらなくね？~~
- `n!autorole` で名前に空白を含むロールに対応
  - `split()` に渡す値が間違っていた
- `n!autorole on` で引数が渡されなかった場合のエラーに対処
- `n!autorole` のヘルプに足りなかったものを追加
- 申し訳程度に flake8 の文句に対応