### PR TITLE
Feat: AutoEmojiの追加

### DIFF
--- a/cogs/autoemoji.py
+++ b/cogs/autoemoji.py
@@ -65,9 +65,11 @@ class AutoEmoji(commands.Cog):
             required=True,
         )
     ):
-        assert isinstance(interaction.guild, nextcord.Guild)
+        assert interaction.guild is not None
         assert interaction.channel is not None
+
         await interaction.response.defer(ephemeral=False)
+
         message = await interaction.followup.send(
             embed=nextcord.Embed(
                 title="しばらくお待ちください...",
@@ -126,7 +128,7 @@ class AutoEmoji(commands.Cog):
                     )
                 )
                 return
-            except nextcord.HTTPException as e:
+            except nextcord.HTTPException:
                 await message.edit(
                     embed=nextcord.Embed(
                         title="AutoEmoji - Error",
@@ -155,6 +157,7 @@ class AutoEmoji(commands.Cog):
                 )
             )
             return
+
         await message.edit(
             embed=nextcord.Embed(
                 title="AutoEmoji - Success",
@@ -175,9 +178,11 @@ class AutoEmoji(commands.Cog):
         }
     )
     async def del_autoemoji_slash(self, interaction: Interaction):
-        await interaction.response.defer(ephemeral=False)
-        assert isinstance(interaction.guild, nextcord.Guild)
+        assert interaction.guild is not None
         assert interaction.channel is not None
+
+        await interaction.response.defer(ephemeral=False)
+
         delete_status = await self.autoemoji_collection.delete_one({"channel_id": interaction.channel.id})
         if delete_status.deleted_count == 0:
             await interaction.send(
@@ -214,10 +219,12 @@ class AutoEmoji(commands.Cog):
         }
     )
     async def list_autoemoji_slash(self, interaction: Interaction):
-        await interaction.response.defer(ephemeral=False)
         assert interaction.channel is not None
+        channel = interaction.channel
 
-        autoemoji_settings = list(filter(lambda x: x["channel_id"] == interaction.channel.id, self.autoemoji_list))
+        await interaction.response.defer(ephemeral=False)
+
+        autoemoji_settings = list(filter(lambda x: x["channel_id"] == channel.id, self.autoemoji_list))
         if len(autoemoji_settings) == 0:
             await interaction.send(
                 embed=nextcord.Embed(

--- a/cogs/autoemoji.py
+++ b/cogs/autoemoji.py
@@ -205,6 +205,44 @@ class AutoEmoji(commands.Cog):
                 self.autoemoji_list.remove(autoemoji)
                 break
 
+    @application_checks.guild_only()
+    @autoemoji_slash.subcommand(
+        name="list",
+        description="List autoemoji settings",
+        description_localizations={
+            nextcord.Locale.ja: "自動絵文字の設定を表示します。",
+        }
+    )
+    async def list_autoemoji_slash(self, interaction: Interaction):
+        await interaction.response.defer(ephemeral=False)
+        assert interaction.channel is not None
+
+        autoemoji_settings = list(filter(lambda x: x["channel_id"] == interaction.channel.id, self.autoemoji_list))
+        if len(autoemoji_settings) == 0:
+            await interaction.send(
+                embed=nextcord.Embed(
+                    title="AutoEmoji - List",
+                    description="このチャンネルには自動絵文字が設定されていません。",
+                    color=self.bot.color.NORMAL
+                ),
+                ephemeral=True
+            )
+            return
+        autoemoji_setting = autoemoji_settings[0]
+        emoji_list = autoemoji_setting["emojis"]
+        await interaction.send(
+            embed=nextcord.Embed(
+                title="AutoEmoji - List",
+                description=(
+                    "このチャンネルでリアクションするように設定されている絵文字は以下の通りです。\n"
+                    f"{', '.join(emoji_list)}\n"
+                    f"(`{', '.join(emoji_list)}`)"
+                ),
+                color=self.bot.color.NORMAL
+            ),
+            ephemeral=True
+        )
+
     @commands.Cog.listener()
     async def on_message(self, message: nextcord.Message):
         if not message.guild:

--- a/cogs/autoemoji.py
+++ b/cogs/autoemoji.py
@@ -1,0 +1,232 @@
+import asyncio
+from motor import motor_asyncio
+from typing import Any, TypedDict
+
+import nextcord
+from nextcord import Interaction, SlashOption
+from nextcord.ext import commands, application_checks, tasks
+
+from util.nira import NIRA
+
+class AutoEmojiSetting(TypedDict):
+    """
+    `AutoEmoji.autoemoji_list`に使用される、AutoEmojiの設定を表す型です。
+    """
+    channel_id: int
+    emojis: list[str]
+
+class AutoEmoji(commands.Cog):
+    """
+    AutoEmojiは、設定チャンネルにメッセージが投稿された際に、自動で絵文字リアクションを行う機能です。
+    これを行うことでチャンネル運用がもしかしたら便利になるかもしれません。
+    """
+    def __init__(self, bot: NIRA, **kwargs: Any):
+        self.bot = bot
+        self.autoemoji_collection: motor_asyncio.AsyncIOMotorCollection = self.bot.database["autoemoji_setting"]
+        self.autoemoji_list: list[AutoEmojiSetting] = []
+        self.load_autoemoji_settings.start()
+
+    @tasks.loop(hours=1.0)
+    async def load_autoemoji_settings(self):
+        """
+        AutoEmojiの設定を、データベースからローカルへロードします。
+        """
+        self.autoemoji_list = []
+        async for autoemoji in self.autoemoji_collection.find():
+            self.autoemoji_list.append(autoemoji)
+
+    @nextcord.slash_command(
+        name="autoemoji",
+        description="Configure autoemoji settings",
+    )
+    async def autoemoji_slash(self, interaction: Interaction):
+        pass
+
+    @application_checks.guild_only()
+    @autoemoji_slash.subcommand(
+        name="add",
+        description="Add a new autoemoji",
+        description_localizations={
+            nextcord.Locale.ja: "新しい自動絵文字を追加します。",
+        }
+    )
+    async def add_autoemoji_slash(
+        self,
+        interaction: Interaction,
+        emojis: str = SlashOption(
+            name="emojis",
+            name_localizations={
+                nextcord.Locale.ja: "絵文字",
+            },
+            description="Comma separated emojis to add",
+            description_localizations={
+                nextcord.Locale.ja: "カンマ区切りで絵文字を指定してください。",
+            },
+            required=True,
+        )
+    ):
+        assert isinstance(interaction.guild, nextcord.Guild)
+        assert interaction.channel is not None
+        await interaction.response.defer(ephemeral=False)
+        message = await interaction.followup.send(
+            embed=nextcord.Embed(
+                title="しばらくお待ちください...",
+                description="絵文字のチェックを行っています。",
+                color=self.bot.color.ATTENTION
+            ),
+            wait=True
+        )
+        emojis = emojis.replace(" ", "")
+        emoji_list = emojis.split(",")
+        if len(emoji_list) > 10:
+            await message.edit(
+                embed=nextcord.Embed(
+                    title="AutoEmoji - Error",
+                    description="設定できる絵文字は10個までです。",
+                    color=self.bot.color.ERROR
+                )
+            )
+            return
+        for emoji in emoji_list:
+            try:
+                await message.add_reaction(emoji)
+            except nextcord.Forbidden:
+                await message.edit(
+                    embed=nextcord.Embed(
+                        title="AutoEmoji - Error",
+                        description=(
+                            f"絵文字 {emoji} (`{emoji}`)の確認時にエラーが発生しました。\n"
+                            "絵文字を追加する権限がありませんでした。"
+                        ),
+                        color=self.bot.color.ERROR
+                    )
+                )
+                return
+            except nextcord.NotFound:
+                await message.edit(
+                    embed=nextcord.Embed(
+                        title="AutoEmoji - Error",
+                        description=(
+                            f"絵文字 {emoji} (`{emoji}`)の確認時にエラーが発生しました。\n"
+                            "絵文字が見つかりませんでした。"
+                        ),
+                        color=self.bot.color.ERROR
+                    )
+                )
+                return
+            except nextcord.InvalidArgument:
+                await message.edit(
+                    embed=nextcord.Embed(
+                        title="AutoEmoji - Error",
+                        description=(
+                            f"絵文字 {emoji} (`{emoji}`)の確認時にエラーが発生しました。\n"
+                            "絵文字が無効です。"
+                        ),
+                        color=self.bot.color.ERROR
+                    )
+                )
+                return
+            except nextcord.HTTPException as e:
+                await message.edit(
+                    embed=nextcord.Embed(
+                        title="AutoEmoji - Error",
+                        description=(
+                            f"絵文字 {emoji} (`{emoji}`)の確認時にエラーが発生しました。\n"
+                            "絵文字はカンマ区切りで入力されているかご確認ください。\n"
+                            "または...一時的なネットワークエラーが発生している可能性があります。"
+                        ),
+                        color=self.bot.color.ERROR
+                    )
+                )
+                return
+        try:
+            await self.autoemoji_collection.update_one(
+                filter={"channel_id": interaction.channel.id},
+                update={"$set": {"emojis": emoji_list}},
+                upsert=True
+            )
+            self.autoemoji_list.append({"channel_id": interaction.channel.id, "emojis": emoji_list})
+        except Exception as e:
+            await message.edit(
+                embed=nextcord.Embed(
+                    title="AutoEmoji - Error",
+                    description=f"エラーが発生しました。\n```{e}```",
+                    color=self.bot.color.ERROR
+                )
+            )
+            return
+        await message.edit(
+            embed=nextcord.Embed(
+                title="AutoEmoji - Success",
+                description=(
+                    f"絵文字 {emojis} (`{emojis}`)をこのチャンネルに追加しました。\n"
+                    "このチャンネルにメッセージが送信されると自動で絵文字リアクションが行われます。"
+                ),
+                color=self.bot.color.NORMAL
+            )
+        )
+
+    @application_checks.guild_only()
+    @autoemoji_slash.subcommand(
+        name="del",
+        description="Delete autoemoji from this channel",
+        description_localizations={
+            nextcord.Locale.ja: "このチャンネルの自動絵文字を削除します。",
+        }
+    )
+    async def del_autoemoji_slash(self, interaction: Interaction):
+        await interaction.response.defer(ephemeral=False)
+        assert isinstance(interaction.guild, nextcord.Guild)
+        assert interaction.channel is not None
+        delete_status = await self.autoemoji_collection.delete_one({"channel_id": interaction.channel.id})
+        if delete_status.deleted_count == 0:
+            await interaction.send(
+                embed=nextcord.Embed(
+                    title="AutoEmoji - Error",
+                    description="このチャンネルには自動絵文字が設定されていません。",
+                    color=self.bot.color.ERROR
+                ),
+                ephemeral=True
+            )
+            return
+        await interaction.send(
+            embed=nextcord.Embed(
+                title="AutoEmoji - Success",
+                description=(
+                    "このチャンネルの自動絵文字を削除しました。\n"
+                    "このメッセージにつく絵文字が最後の絵文字だよ..."
+                ),
+                color=self.bot.color.NORMAL
+            ),
+            ephemeral=True
+        )
+        for autoemoji in self.autoemoji_list:
+            if autoemoji["channel_id"] == interaction.channel.id:
+                self.autoemoji_list.remove(autoemoji)
+                break
+
+    @commands.Cog.listener()
+    async def on_message(self, message: nextcord.Message):
+        if not message.guild:
+            return
+        autoemoji_settings = list(filter(lambda x: x["channel_id"] == message.channel.id, self.autoemoji_list))
+        print(autoemoji_settings)
+        if len(autoemoji_settings) == 0:
+            return
+        autoemoji_setting = autoemoji_settings[0]
+        emoji_list = autoemoji_setting["emojis"]
+        for emoji in emoji_list:
+            try:
+                await message.add_reaction(emoji)
+            except nextcord.Forbidden:
+                pass
+            except nextcord.NotFound:
+                pass
+            except nextcord.InvalidArgument:
+                pass
+            except nextcord.HTTPException:
+                pass
+            await asyncio.sleep(1)
+
+def setup(bot: NIRA, **kwargs: Any):
+    bot.add_cog(AutoEmoji(bot, **kwargs))

--- a/cogs/autoemoji.py
+++ b/cogs/autoemoji.py
@@ -8,11 +8,13 @@ from nextcord.ext import commands, application_checks, tasks
 
 from util.nira import NIRA
 
+
 class AutoEmoji(commands.Cog):
     """
     AutoEmojiは、設定チャンネルにメッセージが投稿された際に、自動で絵文字リアクションを行う機能です。
     これを行うことでチャンネル運用がもしかしたら便利になるかもしれません。
     """
+
     def __init__(self, bot: NIRA, **kwargs: Any):
         self.bot = bot
         self.autoemoji_collection: motor_asyncio.AsyncIOMotorCollection = self.bot.database["autoemoji_setting"]
@@ -41,7 +43,7 @@ class AutoEmoji(commands.Cog):
         description="Set autoemoji to this channel",
         description_localizations={
             nextcord.Locale.ja: "このチャンネルに自動絵文字を設定します。",
-        }
+        },
     )
     async def set_autoemoji_slash(
         self,
@@ -56,7 +58,7 @@ class AutoEmoji(commands.Cog):
                 nextcord.Locale.ja: "設定したい絵文字をカンマ区切りで指定してください。",
             },
             required=True,
-        )
+        ),
     ):
         assert interaction.guild is not None
         assert interaction.channel is not None
@@ -72,9 +74,9 @@ class AutoEmoji(commands.Cog):
                         "このチャンネルには既に自動絵文字が設定されています。\n"
                         "削除するには`/autoemoji del`を使用してください。"
                     ),
-                    color=self.bot.color.ERROR
+                    color=self.bot.color.ERROR,
                 ),
-                ephemeral=True
+                ephemeral=True,
             )
             return
 
@@ -82,9 +84,9 @@ class AutoEmoji(commands.Cog):
             embed=nextcord.Embed(
                 title="しばらくお待ちください...",
                 description="絵文字のチェックを行っています。",
-                color=self.bot.color.ATTENTION
+                color=self.bot.color.ATTENTION,
             ),
-            wait=True
+            wait=True,
         )
         emojis = emojis.replace(" ", "")
         emoji_list = emojis.split(",")
@@ -93,7 +95,7 @@ class AutoEmoji(commands.Cog):
                 embed=nextcord.Embed(
                     title="AutoEmoji - Error",
                     description="設定できる絵文字は10個までです。",
-                    color=self.bot.color.ERROR
+                    color=self.bot.color.ERROR,
                 )
             )
             return
@@ -108,7 +110,7 @@ class AutoEmoji(commands.Cog):
                             f"絵文字 {emoji} (`{emoji}`)の確認時にエラーが発生しました。\n"
                             "絵文字を追加する権限がありませんでした。"
                         ),
-                        color=self.bot.color.ERROR
+                        color=self.bot.color.ERROR,
                     )
                 )
                 return
@@ -120,7 +122,7 @@ class AutoEmoji(commands.Cog):
                             f"絵文字 {emoji} (`{emoji}`)の確認時にエラーが発生しました。\n"
                             "絵文字が見つかりませんでした。"
                         ),
-                        color=self.bot.color.ERROR
+                        color=self.bot.color.ERROR,
                     )
                 )
                 return
@@ -132,7 +134,7 @@ class AutoEmoji(commands.Cog):
                             f"絵文字 {emoji} (`{emoji}`)の確認時にエラーが発生しました。\n"
                             "絵文字が無効です。"
                         ),
-                        color=self.bot.color.ERROR
+                        color=self.bot.color.ERROR,
                     )
                 )
                 return
@@ -145,7 +147,7 @@ class AutoEmoji(commands.Cog):
                             "絵文字はカンマ区切りで入力されているかご確認ください。\n"
                             "または...一時的なネットワークエラーが発生している可能性があります。"
                         ),
-                        color=self.bot.color.ERROR
+                        color=self.bot.color.ERROR,
                     )
                 )
                 return
@@ -153,7 +155,7 @@ class AutoEmoji(commands.Cog):
             await self.autoemoji_collection.update_one(
                 filter={"channel_id": interaction.channel.id},
                 update={"$set": {"emojis": emoji_list}},
-                upsert=True
+                upsert=True,
             )
             self.autoemoji_cache[interaction.channel.id] = emoji_list
         except Exception as e:
@@ -161,7 +163,7 @@ class AutoEmoji(commands.Cog):
                 embed=nextcord.Embed(
                     title="AutoEmoji - Error",
                     description=f"エラーが発生しました。\n```{e}```",
-                    color=self.bot.color.ERROR
+                    color=self.bot.color.ERROR,
                 )
             )
             return
@@ -173,7 +175,7 @@ class AutoEmoji(commands.Cog):
                     f"絵文字 {emojis} (`{emojis}`)をこのチャンネルに追加しました。\n"
                     "このチャンネルにメッセージが送信されると自動で絵文字リアクションが行われます。"
                 ),
-                color=self.bot.color.NORMAL
+                color=self.bot.color.NORMAL,
             )
         )
 
@@ -183,7 +185,7 @@ class AutoEmoji(commands.Cog):
         description="Delete autoemoji from this channel",
         description_localizations={
             nextcord.Locale.ja: "このチャンネルの自動絵文字を削除します。",
-        }
+        },
     )
     async def del_autoemoji_slash(self, interaction: Interaction):
         assert interaction.guild is not None
@@ -197,9 +199,9 @@ class AutoEmoji(commands.Cog):
                 embed=nextcord.Embed(
                     title="AutoEmoji - Error",
                     description="このチャンネルには自動絵文字が設定されていません。",
-                    color=self.bot.color.ERROR
+                    color=self.bot.color.ERROR,
                 ),
-                ephemeral=True
+                ephemeral=True,
             )
             return
         await interaction.send(
@@ -209,9 +211,9 @@ class AutoEmoji(commands.Cog):
                     "このチャンネルの自動絵文字を削除しました。\n"
                     "このメッセージにつく絵文字が最後の絵文字だよ..."
                 ),
-                color=self.bot.color.NORMAL
+                color=self.bot.color.NORMAL,
             ),
-            ephemeral=True
+            ephemeral=True,
         )
         self.autoemoji_cache.pop(interaction.channel.id, None)
 
@@ -221,7 +223,7 @@ class AutoEmoji(commands.Cog):
         description="List autoemoji settings",
         description_localizations={
             nextcord.Locale.ja: "自動絵文字の設定を表示します。",
-        }
+        },
     )
     async def list_autoemoji_slash(self, interaction: Interaction):
         assert interaction.channel is not None
@@ -234,9 +236,9 @@ class AutoEmoji(commands.Cog):
                 embed=nextcord.Embed(
                     title="AutoEmoji - List",
                     description="このチャンネルには自動絵文字が設定されていません。",
-                    color=self.bot.color.NORMAL
+                    color=self.bot.color.NORMAL,
                 ),
-                ephemeral=True
+                ephemeral=True,
             )
             return
         emoji_list = self.autoemoji_cache[interaction.channel.id]
@@ -248,9 +250,9 @@ class AutoEmoji(commands.Cog):
                     f"{', '.join(emoji_list)}\n"
                     f"(`{', '.join(emoji_list)}`)"
                 ),
-                color=self.bot.color.NORMAL
+                color=self.bot.color.NORMAL,
             ),
-            ephemeral=True
+            ephemeral=True,
         )
 
     @commands.Cog.listener()
@@ -272,6 +274,7 @@ class AutoEmoji(commands.Cog):
             except nextcord.HTTPException:
                 pass
             await asyncio.sleep(1)
+
 
 def setup(bot: NIRA, **kwargs: Any):
     bot.add_cog(AutoEmoji(bot, **kwargs))

--- a/cogs/autoemoji.py
+++ b/cogs/autoemoji.py
@@ -75,8 +75,7 @@ class AutoEmoji(commands.Cog):
                         "削除するには`/autoemoji del`を使用してください。"
                     ),
                     color=self.bot.color.ERROR,
-                ),
-                ephemeral=True,
+                )
             )
             return
 

--- a/cogs/autoemoji.py
+++ b/cogs/autoemoji.py
@@ -227,7 +227,6 @@ class AutoEmoji(commands.Cog):
     )
     async def list_autoemoji_slash(self, interaction: Interaction):
         assert interaction.channel is not None
-        channel = interaction.channel
 
         await interaction.response.defer(ephemeral=False)
 

--- a/cogs/autoemoji.py
+++ b/cogs/autoemoji.py
@@ -210,7 +210,6 @@ class AutoEmoji(commands.Cog):
         if not message.guild:
             return
         autoemoji_settings = list(filter(lambda x: x["channel_id"] == message.channel.id, self.autoemoji_list))
-        print(autoemoji_settings)
         if len(autoemoji_settings) == 0:
             return
         autoemoji_setting = autoemoji_settings[0]

--- a/cogs/autoemoji.py
+++ b/cogs/autoemoji.py
@@ -103,54 +103,26 @@ class AutoEmoji(commands.Cog):
             try:
                 await message.add_reaction(emoji)
             except nextcord.Forbidden:
-                await message.edit(
-                    embed=nextcord.Embed(
-                        title="AutoEmoji - Error",
-                        description=(
-                            f"絵文字 {emoji} (`{emoji}`)の確認時にエラーが発生しました。\n"
-                            "絵文字を追加する権限がありませんでした。"
-                        ),
-                        color=self.bot.color.ERROR,
-                    )
-                )
-                return
+                description = "絵文字を追加する権限がありませんでした。"
             except nextcord.NotFound:
-                await message.edit(
-                    embed=nextcord.Embed(
-                        title="AutoEmoji - Error",
-                        description=(
-                            f"絵文字 {emoji} (`{emoji}`)の確認時にエラーが発生しました。\n"
-                            "絵文字が見つかりませんでした。"
-                        ),
-                        color=self.bot.color.ERROR,
-                    )
-                )
-                return
+                description = "絵文字が見つかりませんでした。"
             except nextcord.InvalidArgument:
-                await message.edit(
-                    embed=nextcord.Embed(
-                        title="AutoEmoji - Error",
-                        description=(
-                            f"絵文字 {emoji} (`{emoji}`)の確認時にエラーが発生しました。\n"
-                            "絵文字が無効です。"
-                        ),
-                        color=self.bot.color.ERROR,
-                    )
-                )
-                return
+                description = "絵文字が無効です。"
             except nextcord.HTTPException:
-                await message.edit(
-                    embed=nextcord.Embed(
-                        title="AutoEmoji - Error",
-                        description=(
-                            f"絵文字 {emoji} (`{emoji}`)の確認時にエラーが発生しました。\n"
-                            "絵文字はカンマ区切りで入力されているかご確認ください。\n"
-                            "または...一時的なネットワークエラーが発生している可能性があります。"
-                        ),
-                        color=self.bot.color.ERROR,
-                    )
+                description = (
+                    "絵文字はカンマ区切りで入力されているかご確認ください。\n"
+                    "または...一時的なネットワークエラーが発生している可能性があります。"
                 )
-                return
+            else:
+                continue
+            await message.edit(
+                embed=nextcord.Embed(
+                    title="AutoEmoji - Error",
+                    description=f"絵文字 {emoji} (`{emoji}`)の確認時にエラーが発生しました。\n{description}",
+                    color=self.bot.color.ERROR,
+                )
+            )
+            return
         try:
             await self.autoemoji_collection.update_one(
                 filter={"channel_id": interaction.channel.id},

--- a/cogs/reaction.py
+++ b/cogs/reaction.py
@@ -223,8 +223,8 @@ class Reaction(commands.Cog):
             },
             choice_localizations={
                 nextcord.Locale.ja: {
-                    "有効": True,
-                    "無効": False
+                    "有効": "True",
+                    "無効": "False"
                 }
             },
             default=False

--- a/cogs/reaction.py
+++ b/cogs/reaction.py
@@ -217,15 +217,9 @@ class Reaction(commands.Cog):
                 nextcord.Locale.ja: "メンションするかどうかです"
             },
             required=False,
-            choices={
-                "True": True,
-                "False": False
-            },
+            choices={"Enable": True, "Disable": False},
             choice_localizations={
-                nextcord.Locale.ja: {
-                    "有効": "True",
-                    "無効": "False"
-                }
+                nextcord.Locale.ja: {"Enable": "有効", "Disable": "無効"}
             },
             default=False
         )
@@ -312,7 +306,7 @@ class Reaction(commands.Cog):
             },
             required=True
         ),
-        mention: str = SlashOption(
+        mention: bool = SlashOption(
             name="mention",
             name_localizations={
                 nextcord.Locale.ja: "メンション"
@@ -321,25 +315,16 @@ class Reaction(commands.Cog):
             description_localizations={
                 nextcord.Locale.ja: "メンションをするかどうかです"
             },
-            required=False,
-            default="None",
-            choices={
-                "Enable": "True",
-                "Disable": "False"
-            },
+            choices={"Enable": True, "Disable": False},
             choice_localizations={
-                nextcord.Locale.ja: {
-                    "有効": "True",
-                    "無効": "False"
-                }
-            }
+                nextcord.Locale.ja: {"Enable": "有効", "Disable": "無効"}
+            },
+            required=False,
+            default=False
         )
     ):
         await interaction.response.defer(ephemeral=True)
-        if mention == "None":
-            update_value = {"return": returnMessage}
-        else:
-            update_value = {"return": returnMessage, "mention": True if mention == "True" else False}
+        update_value = {"return": returnMessage, "mention": mention}
         edit_result = await self.er_collection.update_one({"guild_id": interaction.guild.id, "trigger": triggerMessage}, {"$set": update_value})
         if edit_result.modified_count == 0:
             await interaction.followup.send(embed=nextcord.Embed(title="Error", description=f"追加反応が存在しませんでした。", color=0xff0000))
@@ -423,7 +408,7 @@ class Reaction(commands.Cog):
                 },
                 choices={"Enable": True, "Disable": False},
                 choice_localizations={
-                    nextcord.Locale.ja: {"有効": False, "無効": True}
+                    nextcord.Locale.ja: {"Enable": "有効", "Disable": "無効"}
                 },
                 required=True
             )
@@ -448,7 +433,7 @@ class Reaction(commands.Cog):
                 },
                 choices={"Enable": True, "Disable": False},
                 choice_localizations={
-                    nextcord.Locale.ja: {"有効": True, "無効": False}
+                    nextcord.Locale.ja: {"Enable": "有効", "Disable": "無効"}
                 },
                 required=True
             )
@@ -503,7 +488,7 @@ class Reaction(commands.Cog):
                 },
                 choices={"Enable": True, "Disable": False},
                 choice_localizations={
-                    nextcord.Locale.ja: {"有効": False, "無効": True}
+                    nextcord.Locale.ja: {"Enable": "有効", "Disable": "無効"}
                 }
             )
         ):

--- a/cogs/reaction.py
+++ b/cogs/reaction.py
@@ -107,14 +107,14 @@ class Reaction(commands.Cog):
                 await ctx.reply(embed=nextcord.Embed(title="Error", description=f"管理者権限がありません。", color=0xff0000))
                 return
             if mention in n_fc.on_ali:
-                mention = True
+                mention_setting = True
             elif mention in n_fc.off_ali:
-                mention = False
+                mention_setting = False
             else:
                 await ctx.reply(embed=nextcord.Embed(title="Error", description=f"返信に対するメンションの指定が不正です。\n`yes`や`True`又は、`off`や`False`で指定してください。", color=0xff0000))
                 return
-            await self.er_collection.update_one({"guild_id": ctx.guild.id, "trigger": trigger}, {"$set": {"return": return_text, "mention": mention}}, upsert=True)
-            await ctx.reply(embed=nextcord.Embed(title="Success", description=f"トリガー`{trigger}`を追加しました。\nメンションは{'有効' if mention else '無効'}です。\n{self._atdb}", color=0x00ff00))
+            await self.er_collection.update_one({"guild_id": ctx.guild.id, "trigger": trigger}, {"$set": {"return": return_text, "mention": mention_setting}}, upsert=True)
+            await ctx.reply(embed=nextcord.Embed(title="Success", description=f"トリガー`{trigger}`を追加しました。\nメンションは{'有効' if mention_setting else '無効'}です。\n{self._atdb}", color=0x00ff00))
 
     @commands.has_permissions(manage_guild=True)
     @er_command.command(name="del")


### PR DESCRIPTION
# 概要
- サポートより、特定のチャンネルにおいて絵文字のリアクションを自動でつけてくれるような機能
（これ以上でもこれ以下でも）

`reaction.py`のコードに手がかかってる理由は、もともと`er`のオプション機能として追加しようとしたが、要望とはまったくちげぇなこれってなったので半分ミスみたいなもん。