### PR TITLE
hotfix (autorole): 設定確認コマンドで削除されてしまう

### DIFF
--- a/cogs/autorole.py
+++ b/cogs/autorole.py
@@ -48,7 +48,7 @@ class autorole(commands.Cog):
                 return ("サーバーで自動ロールを無効にしました。", None)
 
         else:
-            result = await self.collection.delete_one({"guild_id": guild.id})
+            result = await self.collection.find_one({"guild_id": guild.id})
             if result is not None:
                 msg = f"自動ロールは有効です。\n自動付与されるロールは{guild.get_role(result['role_id']).mention}です。"
             else:


### PR DESCRIPTION
タイトル通り。  
`n!autorole` とか `/autorole status` とかした瞬間に設定が消えてしまう。もちろん消えたことは通知なし。  
しかも出てくるトレースバックでは設定がされていたかのように見えるため、大変混乱を与えやすく非常にヤバイ。

## 経緯
自動ロールの設定を確認しようとしてエラーが出たもんだから、どうなってるのかとコードみたら `delete_one` とか書いてあってびっくり。  
この[コミット](https://github.com/team-i2021/nira_bot/commit/da53bcb026db012038a4b80c2f2a30ea710042b5)15ヶ月前って…もう考えたくない…