### PR TITLE
fix: 既にVCから離脱しているときの処理修正

### DIFF
--- a/cogs/tts.py
+++ b/cogs/tts.py
@@ -83,6 +83,7 @@ class Text2Speech(commands.Cog):
             self.parent = parent
             self.author = author
             options = [
+                nextcord.SelectOption(label="8期生", value="8"),
                 nextcord.SelectOption(label="7期生", value="7"),
                 nextcord.SelectOption(label="6期生", value="6"),
                 nextcord.SelectOption(label="5期生", value="5"),
@@ -119,6 +120,13 @@ class Text2Speech(commands.Cog):
             self.generation = generation
 
             match generation:
+                case "8":
+                    options = [
+                        nextcord.SelectOption(label="栗田まろん", value="26"),
+                        nextcord.SelectOption(label="あいえるたん", value="27"),
+                        nextcord.SelectOption(label="満別花丸", value="28"),
+                        nextcord.SelectOption(label="琴詠ニア", value="29"),
+                    ]
                 case "7":
                     options = [
                         nextcord.SelectOption(label="†聖騎士紅桜†", value="19"),

--- a/cogs/tts.py
+++ b/cogs/tts.py
@@ -552,6 +552,8 @@ TTSの読み上げ音声には、VOICEVOXが使われています。
                     asyncio.ensure_future(self.collection.update_one({"user_id": interaction.user.id, "type": "speaker"}, {"$set": {"speaker": "2"}}, upsert=True))
                 if interaction.guild.voice_client.is_playing():
                     while True:
+                        if message.guild.voice_client is None:
+                            return
                         if interaction.guild.voice_client.is_playing():
                             await asyncio.sleep(0.1)
                         else:
@@ -594,6 +596,8 @@ TTSの読み上げ音声には、VOICEVOXが使われています。
                 return
             if message.guild.voice_client.is_playing():
                 while True:
+                    if message.guild.voice_client is None:
+                        return
                     if message.guild.voice_client.is_playing():
                         await asyncio.sleep(0.1)
                     else:


### PR DESCRIPTION
# 概要
- 読み上げ中に新しいチャットが送られることによる、読み上げ待ちが発生しているときの処理修正
- ついでにボイボ8期生の追加

## 修正
BOTがメッセージを読み上げている間に新しいメッセージを送られると、そのメッセージを次以降に読み上げるために待機を行っている。
その待機が行われている間に何らかの理由でBOTがVCから切断されていると、`is_playing()`の処理実行時に既に`voice_client`が`None`になっており、待機しているメッセージがあればあるほどエラーメッセージが爆発する。
現在は`voice_client`が`None`なら処理を打ち切るようにしている。

## 追加
読み上げキャラクターの追加。

## その他
（別に急は要していないが、直近でコードを直しただけのため）特になし。