### PR TITLE
fix: VC周りの改善

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -3,13 +3,16 @@ import datetime
 import logging
 import re
 import sys
+import typing
 
 import nextcord
 import niconico_dl
 from nextcord.ext import commands
 
-from cogs import tts
 from util import n_fc
+
+if typing.TYPE_CHECKING:
+    from cogs.tts import Text2Speech
 
 # 音楽再生
 
@@ -158,7 +161,8 @@ Discord及びGoogleは、DiscordのボイスチャンネルでのYouTube再生BO
                 return
             else:
                 if ctx.guild.voice_client is not None:
-                    if ctx.guild.id not in tts.tts_channel:
+                    tts = typing.cast("Text2Speech | None", self.bot.get_cog("Text2Speech"))
+                    if not tts or ctx.guild.id not in tts.TTS_CHANNEL:
                         await ctx.message.reply(
                             embed=nextcord.Embed(title="エラー", description="既にVCに入っています。", color=0xFF0000)
                         )
@@ -378,11 +382,13 @@ Discord及びGoogleは、DiscordのボイスチャンネルでのYouTube再生BO
     音楽系のコマンドの詳細は[こちら](https://sites.google.com/view/nira-bot/%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89/music)からご確認ください。""",
     )
     async def leave(self, ctx: commands.Context):
+        tts = typing.cast("Text2Speech | None", self.bot.get_cog("Text2Speech"))
         if len(ctx.message.content.split(" ", 1)) > 1 and ctx.message.content.split(" ", 1)[1] == "f":
-            try:
-                del tts.tts_list[ctx.guild.id]
-            except Exception:
-                pass
+            if tts:
+                try:
+                    del tts.TTS_CHANNEL[ctx.guild.id]
+                except Exception:
+                    pass
             try:
                 del music_list[ctx.guild.id]
             except Exception:
@@ -412,7 +418,7 @@ Discord及びGoogleは、DiscordのボイスチャンネルでのYouTube再生BO
                 )
                 return
             else:
-                if ctx.guild.id not in tts.tts_channel.value:
+                if not tts or ctx.guild.id not in tts.TTS_CHANNEL:
                     await ctx.guild.voice_client.disconnect()
                     await ctx.message.reply(
                         embed=nextcord.Embed(title="Music Player", description="切断しました。", color=0x00FF00)

--- a/cogs/tts.py
+++ b/cogs/tts.py
@@ -83,6 +83,7 @@ class Text2Speech(commands.Cog):
             self.parent = parent
             self.author = author
             options = [
+                nextcord.SelectOption(label="8期生", value="8"),
                 nextcord.SelectOption(label="7期生", value="7"),
                 nextcord.SelectOption(label="6期生", value="6"),
                 nextcord.SelectOption(label="5期生", value="5"),
@@ -119,6 +120,13 @@ class Text2Speech(commands.Cog):
             self.generation = generation
 
             match generation:
+                case "8":
+                    options = [
+                        nextcord.SelectOption(label="栗田まろん", value="26"),
+                        nextcord.SelectOption(label="あいえるたん", value="27"),
+                        nextcord.SelectOption(label="満別花丸", value="28"),
+                        nextcord.SelectOption(label="琴詠ニア", value="29"),
+                    ]
                 case "7":
                     options = [
                         nextcord.SelectOption(label="†聖騎士紅桜†", value="19"),

--- a/cogs/tts.py
+++ b/cogs/tts.py
@@ -552,6 +552,8 @@ TTSの読み上げ音声には、VOICEVOXが使われています。
                     asyncio.ensure_future(self.collection.update_one({"user_id": interaction.user.id, "type": "speaker"}, {"$set": {"speaker": "2"}}, upsert=True))
                 if interaction.guild.voice_client.is_playing():
                     while True:
+                        if message.guild.voice_client is None:
+                            return
                         if interaction.guild.voice_client.is_playing():
                             await asyncio.sleep(0.1)
                         else:
@@ -594,6 +596,8 @@ TTSの読み上げ音声には、VOICEVOXが使われています。
                 return
             if message.guild.voice_client.is_playing():
                 while True:
+                    if message.guild.voice_client is None:
+                        return
                     if message.guild.voice_client.is_playing():
                         await asyncio.sleep(0.1)
                     else:


### PR DESCRIPTION
# Add
- VOICEVOX 8期生の追加 #72

# Fix
- 既にVCから離脱しているときの処理修正 #72
- 音楽再生機能使用時にボイスチャンネルから切断できない a5e932e66d7e12bb67d149516d44b080ded7d0c2

# 概要
- TTS周りは上記プルリクエストの通り。  
- `music.py`にある既にTTSがVCを使っているかの判定が古いままで、VCからの切断に失敗する（のとTTS使用中に接続しようとすると例外が発生する）。  
  [`Bot.get_cog()`](https://docs.nextcord.dev/en/stable/ext/commands/api.html#nextcord.ext.commands.Bot.get_cog)でTTSのCogを取得するようにして対処。