### PR TITLE
fix: 大半のサーバーにApplicationCommandsが実装できていなかった

### DIFF
--- a/nira.py
+++ b/nira.py
@@ -78,7 +78,7 @@ bot = NIRA(
     status=nextcord.Status.dnd,
     activity=nextcord.Game(name="Connecting...", type=1),
     rollout_delete_unknown=not DEBUG,
-    default_guild_ids=list(settings.guild_ids) if settings.guild_ids else None
+    default_guild_ids=list(settings.guild_ids) if DEBUG else None
 )
 
 bot.load_extension("onami")


### PR DESCRIPTION
イメージとしては、デバッグモードの時だけは、ApplicationCommandsをGuildに対してdeployして、テストを楽にするというような仕様だった。
が、実際のところはデバッグモードでなくても (設定で`guild_ids`を指定していると) 上記仕様になっており、通常起動でApplicationCommandsが使えないというような不具合につながった。

とりあえず、`default_guild_ids`に値を渡すのをデバッグモードの時だけと修正した。
(なんか昔直したような気もしたんだけど...?)

> ここら辺は`feat-contribute`で修正をする予定でもあるので、今回はとりあえずこれだけ。