### PR TITLE
Feat: pycld2 → fast-langdetect

### DIFF
--- a/cogs/translate.py
+++ b/cogs/translate.py
@@ -1,9 +1,10 @@
+import asyncio
 import re
 import sys
 
 import deepl
+import fast_langdetect  # pyright: ignore[reportMissingTypeStubs]
 import nextcord
-import pycld2
 from googletrans import Translator
 from nextcord import Interaction, SlashOption, ChannelType
 from nextcord.ext import commands
@@ -110,12 +111,16 @@ async def translation(bot: commands.Bot, deepl_tr: deepl.Translator, google_tr: 
     return (result.text, translate)
 
 
-def languageCheck(text: str) -> str:
-    isReliable, textBytesFound, details = pycld2.detect(text)
-    if "ja" == details[0][1]:
-        return "JA"
-    else:
-        return "EN"
+_lock_langdetect = asyncio.Lock()
+
+
+async def languageCheck(text: str) -> str:
+    # 恐らくスレッドセーフではないのでロックをかける
+    async with _lock_langdetect:
+        # ローカルに学習済みモデルが存在しない場合はダウンロードする仕様であるが、
+        # 同期コードでありイベントループをブロックしてしまうので、スレッドに逃がして回避する
+        result = await asyncio.to_thread(fast_langdetect.detect, text, model="auto")
+    return "JA" if result[0]["lang"] == "ja" else "EN"
 
 
 def contentCheck(message: nextcord.Message) -> bool:
@@ -282,7 +287,7 @@ class Translate(commands.Cog):
             )
             return
 
-        sLang = languageCheck(message.content)
+        sLang = await languageCheck(message.content)
         if sLang == "EN":
             sLang, tLang = ("EN", "JA")
         else:
@@ -368,7 +373,7 @@ Powered by DeepL Translate/Google Translate.""")
             elif re.search(u"nira-tl-(ja|en|auto)", message.channel.topic).group() == "nira-tl-en":
                 TARGET = "EN-US"
             elif re.search(u"nira-tl-(ja|en|auto)", message.channel.topic).group() == "nira-tl-auto":
-                sLang = languageCheck(message.content)
+                sLang = await languageCheck(message.content)
                 TARGET = "JA"
                 if sLang == "JA":
                     TARGET = "EN-US"
@@ -391,7 +396,7 @@ Powered by DeepL Translate/Google Translate.""")
             elif re.search(u"nira-tlb-(ja|en|auto)", message.channel.topic).group() == "nira-tlb-en":
                 TARGET = "EN-US"
             elif re.search(u"nira-tlb-(ja|en|auto)", message.channel.topic).group() == "nira-tlb-auto":
-                sLang = languageCheck(message.content)
+                sLang = await languageCheck(message.content)
                 TARGET = "JA"
                 if sLang == "JA":
                     TARGET = "EN-US"

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ python-a2s ~= 1.3.0  # unmaintained
 # Translate
 deepl ~= 1.17.0
 googletrans == 4.0.0-rc1  # unmaintained
-pycld2 @ git+https://github.com/abosamoor/pycld2.git@c71aa20a5cb04c93ac434abafea53bd570c9c1dc  # unmaintained
+fast-langdetect ~= 1.0.0
 
 # TTS
 alkana == 0.0.3  # unmaintained


### PR DESCRIPTION
翻訳機能でメッセージの言語判定に使うライブラリを `pycld2` から `fast-langdetect` に変更。

経緯は #106 を参照。

<details>
<summary>余談</summary>

Q. なんでこのタイミングなの？  
A. 仕事が一段落して余裕ができたから

</details>